### PR TITLE
Fix missing export

### DIFF
--- a/baselinker/__init__.py
+++ b/baselinker/__init__.py
@@ -1,5 +1,16 @@
 from .client import BaseLinkerClient
-from .exceptions import BaseLinkerError, AuthenticationError, RateLimitError
+from .exceptions import (
+    BaseLinkerError,
+    AuthenticationError,
+    RateLimitError,
+    APIError,
+)
 
 __version__ = "0.1.0"
-__all__ = ["BaseLinkerClient", "BaseLinkerError", "AuthenticationError", "RateLimitError"]
+__all__ = [
+    "BaseLinkerClient",
+    "BaseLinkerError",
+    "AuthenticationError",
+    "RateLimitError",
+    "APIError",
+]


### PR DESCRIPTION
## Summary
- export `APIError` from package init so it can be imported directly from `baselinker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685e8f9d6868832680434491d6915dc7